### PR TITLE
3.2: Implement API endpoint for sending a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,92 @@
+# **Hermes: A Real-Time Messaging Application**
+
+Hermes is a full-stack real-time messaging application built to demonstrate proficiency in various web development technologies and architectural patterns. The goal is to create a robust and feature-rich platform for users to communicate instantly.
+
+## **Features**
+
+- **User Authentication:** Secure signup, login, and session management using Supabase Auth.
+- **User Profiles:** Customizable user profiles with usernames and avatars.
+- **Direct Messaging:** Real-time one-on-one conversations between users.
+- **Group Messaging:** (Planned) Create and participate in group chats.
+- **Message Management:** Send, receive, view history (with pagination), edit, and soft-delete messages.
+- **Media & File Sharing:** (Planned) Ability to send images and other file types.
+- **Message Reactions:** (Planned) React to messages with emojis.
+- **Replies/Threading:** (Planned) Reply directly to specific messages.
+- **User Blocking:** (Planned) Block unwanted users.
+- **Real-Time Updates:** Instant message delivery, typing indicators, and presence using Supabase Realtime.
+- **Cross-Platform Sync:** (Planned) Seamless experience across multiple user devices.
+- **Push Notifications:** (Planned) Receive notifications for new messages.
+- **Persistent User Settings:** Customizable application settings per user.
+- **End-to-End Encryption:** (Planned) Secure message content.
+- **Voice/Video Calls:** (Planned) Integrated calling features.
+- **Message Translation:** (Planned) Translate messages within the app.
+- **Chat Bots/AI Integration:** (Planned) Interact with automated bots.
+- **Ephemeral Messages:** (Planned) Messages that automatically disappear after a set time.
+
+## **Goals and Objectives**
+
+The primary goal of the Hermes project is to build a comprehensive messaging application from the ground up, serving as a practical demonstration of:
+
+- Building full-stack applications with Nuxt 3\.
+- Leveraging Supabase as a Backend-as-a-Service (BaaS) for Authentication, Database, Storage, and Realtime.
+- Implementing database schemas and managing them with Prisma.
+- Designing and securing RESTful API endpoints in Nuxt 3 server routes.
+- Implementing robust validation using Zod and integrating it with frontend forms (VeeValidate).
+- Handling real-time data synchronization and events.
+- Implementing secure Row Level Security (RLS) policies in Supabase.
+- Managing file uploads and storage.
+- Structuring a Nuxt 3 application with srcDir and managing module interactions (like @nuxtjs/supabase and @prisma/nuxt).
+- Implementing core UI/UX patterns for a messaging interface, including dark/light themes and loading states.
+- Following a structured development process with defined milestones.
+
+## **Technology Stack**
+
+- **Frontend Framework:** Nuxt 3 (Vue 3\)
+- **Backend/BaaS:** Supabase (PostgreSQL Database, Auth, Storage, Realtime)
+- **ORM:** Prisma
+- **Validation:** Zod (Schema definition), VeeValidate (Form validation)
+- **Styling:** Tailwind CSS
+- **Language:** TypeScript
+
+## **Milestones Checklist**
+
+This checklist tracks the progress through the planned development milestones:
+
+- [ ] **Milestone 1: Project Setup and Core One-on-One Messaging**
+  - [x] 1.1 Project Setup
+  - [x] 1.2 User Authentication (Supabase Auth)
+  - [ ] 1.3 Core Messaging Functionality (Sending/Receiving 1:1)
+- [ ] **Milestone 2: Group Messaging and Core UX**
+  - [ ] 2.1 Group Conversation Support
+  - [ ] 2.2 Conversation List UI
+  - [ ] 2.3 User Status (Online/Offline)
+  - [ ] 2.4 Message History and Pagination
+- [ ] **Milestone 3: Media and File Sharing**
+  - [ ] 3.1 File Upload (Supabase Storage)
+  - [ ] 3.2 Displaying Shared Media/Files
+- [ ] **Milestone 4: Enhanced Messaging Features**
+  - [ ] 4.1 Message Status (Sent/Delivered/Read)
+  - [ ] 4.2 Message Editing
+  - [ ] 4.3 Message Deletion (Soft Delete)
+- [ ] **Milestone 5: Advanced Interactions**
+  - [ ] 5.1 Message Replies/Threading
+  - [ ] 5.2 Message Reactions
+  - [ ] 5.3 User Blocking
+  - [ ] 5.4 Muting Conversations
+- [ ] **Milestone 6: Cross-Platform and Notifications**
+  - [ ] 6.1 Multi-Device Sync
+  - [ ] 6.2 Push Notifications (Basic)
+- [ ] **Milestone 7: Complex Implementations**
+  - [ ] 7.1 End-to-End Encryption (Conceptual/Basic Implementation)
+  - [ ] 7.2 Voice/Video Calls (Basic Integration)
+- [ ] **Milestone 8: Experimental Features**
+  - [ ] 8.1 Message Translation
+  - [ ] 8.2 Chat Bots/AI Integration
+  - [ ] 8.3 Ephemeral Messages
+- [ ] **Milestone 9: Polish, Documentation, and Deployment**
+  - [ ] 9.1 UI/UX Refinements
+  - [ ] 9.2 Performance Optimizations
+  - [ ] 9.3 Documentation
+  - [ ] 9.4 Deployment
+- [ ] **Milestone 10+: Future Enhancements**
+  - [ ] ... (Any features beyond the initial scope)

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -20,6 +20,23 @@
 					"Email not verified.\nPlease click on the confirmation link in the verification email sent to you."
 				);
 
+				const { error: resendError } = await supabase.auth.resend({
+					type: "signup",
+					email: values.email,
+					options: {
+						emailRedirectTo: "http://localhost:3000/confirm"
+					}
+				});
+
+				if (resendError) {
+					alert("Database error.\n\nPlease try again in a minute.");
+					console.error(
+						`Message: ${resendError.message}\nCode: ${resendError.code}\nName: ${resendError.name}`
+					);
+
+					return;
+				}
+
 				return;
 			}
 

--- a/src/components/SignupForm.vue
+++ b/src/components/SignupForm.vue
@@ -4,7 +4,7 @@
 	const confirm = ref("");
 	const confirmMessage = ref("");
 	const success = ref(false);
-	const loading = ref(false)
+	const loading = ref(false);
 
 	const { handleSubmit, errors } = useForm({
 		validationSchema: toTypedSchema(signupSchema)
@@ -28,13 +28,12 @@
 			return;
 		}
 
-		const response = await $fetch('/api/check-username', {
-				method: 'post',
-				query: {
-					username: values.username
-				}
+		const response = await $fetch("/api/users/check-username", {
+			method: "post",
+			query: {
+				username: values.username
 			}
-		);
+		});
 
 		if (response) {
 			alert("Please enter a different username");
@@ -82,7 +81,7 @@
 		>
 	</div>
 	<div class="modal signup" v-else>
-		<span class="form-title">Create account</span>
+		<span class="modal-title">Create account</span>
 		<form @submit="signup">
 			<section>
 				<HInput

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,15 +1,15 @@
-import { PrismaClient } from '@prisma/client'
+import { PrismaClient } from "@prisma/client";
 
 const prismaClientSingleton = () => {
-  return new PrismaClient()
-}
+	return new PrismaClient();
+};
 
 declare const globalThis: {
-  prismaGlobal: ReturnType<typeof prismaClientSingleton>;
+	prismaGlobal: ReturnType<typeof prismaClientSingleton>;
 } & typeof global;
 
-const prisma = globalThis.prismaGlobal ?? prismaClientSingleton()
+const prisma = globalThis.prismaGlobal ?? prismaClientSingleton();
 
-export default prisma
+export default prisma;
 
-if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma
+if (process.env.NODE_ENV !== "production") globalThis.prismaGlobal = prisma;

--- a/src/pages/confirm.vue
+++ b/src/pages/confirm.vue
@@ -1,19 +1,28 @@
 <script lang="ts" setup>
+	const route = useRoute();
+	const tokenHash = route.query.token_hash?.toString();
+	const supabase = useSupabaseClient();
 	const user = useSupabaseUser();
 
-	watch(
-		user,
-		() => {
-			if (user.value) {
-				setTimeout(() => {
-					return navigateTo("/");
-				}, 3000)
-			} else {
-				navigateTo("/")
-			}
-		},
-		{ immediate: true }
-	);
+	if (!tokenHash || user) {
+		navigateTo("/");
+	}
+
+	const { error } = await supabase.auth.verifyOtp({
+		token_hash: tokenHash!,
+		type: "email"
+	});
+
+	if (error) {
+		alert("Database error");
+		console.error(
+			`Message: ${error.message}\nCode: ${error.code}\nName: ${error.name}`
+		);
+	} else {
+		setTimeout(() => {
+			return navigateTo("/");
+		}, 3000);
+	}
 </script>
 
 <template>
@@ -27,6 +36,6 @@
 
 <style scoped>
 	span:nth-child(2) {
-		@apply font-body text-text-secondary pt-4;
+		@apply pt-4 font-body text-text-secondary;
 	}
 </style>

--- a/src/server/api/conversations/find-or-create-direct.post.ts
+++ b/src/server/api/conversations/find-or-create-direct.post.ts
@@ -1,0 +1,95 @@
+import prisma from "~/server/lib/prisma";
+import { serverSupabaseUser } from "#supabase/server";
+import { findOrCreateDirectSchema } from "~/server/validation/conversations";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+
+export default defineEventHandler(async (event) => {
+	let user = null;
+
+	try {
+		user = await serverSupabaseUser(event);
+	} catch (error) {
+		setResponseStatus(event, 401);
+		return { message: "You must be logged in to view conversations" };
+	}
+
+	const result = await readValidatedBody(event, (body) =>
+		findOrCreateDirectSchema.safeParse(body)
+	);
+
+	if (!result.success) {
+		const errors = result.error.issues
+			.map((issue) => `${issue.path.join(".")} - ${issue.message}`)
+			.join("; ");
+
+		setResponseStatus(event, 400);
+		return { message: errors };
+	}
+
+	const memberId = user!.id;
+	const otherMemberId = result.data.otherMemberId;
+
+	if (memberId === otherMemberId) {
+		setResponseStatus(event, 400);
+		return { message: "You can not start a conversation with yourself" };
+	}
+
+	const conversation = await prisma.conversation.findFirst({
+		where: {
+			type: "direct",
+			AND: [
+				{
+					members: {
+						some: {
+							user_id: memberId
+						}
+					}
+				},
+				{
+					members: {
+						some: {
+							user_id: otherMemberId
+						}
+					}
+				}
+			]
+		},
+		select: {
+			id: true
+		}
+	});
+
+	if (conversation) {
+		setResponseStatus(event, 200);
+		return { conversationId: conversation.id };
+	}
+
+	try {
+		const newConversation = await prisma.conversation.create({
+			data: {
+				type: "direct",
+				members: {
+					create: [
+						{
+							user_id: memberId
+						},
+						{
+							user_id: otherMemberId
+						}
+					]
+				}
+			}
+		});
+
+		setResponseStatus(event, 200);
+		return { conversationId: newConversation.id };
+	} catch (error) {
+		if (error instanceof PrismaClientKnownRequestError) {
+			setResponseStatus(event, 500);
+			return { message: error.message };
+		}
+	}
+
+	setResponseStatus(event, 500);
+	return { message: "A server error has occurred" };
+});

--- a/src/server/api/messages/index.post.ts
+++ b/src/server/api/messages/index.post.ts
@@ -1,0 +1,69 @@
+import prisma from "~/server/lib/prisma";
+import { sendMessageSchema } from "~/server/validation/messages";
+import { serverSupabaseUser } from "#supabase/server";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
+
+export default defineEventHandler(async (event) => {
+	let user = null;
+
+	try {
+		user = await serverSupabaseUser(event);
+	} catch (error) {
+		setResponseStatus(event, 401);
+		return { message: "You must be logged in to send messages" };
+	}
+
+	const result = await readValidatedBody(event, (body) =>
+		sendMessageSchema.safeParse(body)
+	);
+
+	if (!result.success) {
+		const errors = result.error.issues
+			.map((issue) => `${issue.path.join(".")} - ${issue.message}`)
+			.join("; ");
+
+		setResponseStatus(event, 400);
+		return { message: errors };
+	}
+
+	const senderId = user!.id;
+	const { conversationId, content } = result.data;
+
+	try {
+		const conversationMember = await prisma.conversationMember.findUnique({
+			where: {
+				user_id_conversation_id: {
+					user_id: senderId,
+					conversation_id: conversationId
+				}
+			},
+			select: {
+				conversation_id: true
+			}
+		});
+
+		if (!conversationMember) {
+			setResponseStatus(event, 403);
+			return { message: "You're are not a member of this conversation" };
+		}
+
+		await prisma.message.create({
+			data: {
+				conversation_id: conversationId,
+				sender_id: senderId,
+				content: content
+			}
+		});
+
+		setResponseStatus(event, 201);
+		return { message: "Message sent successfully" };
+	} catch (error) {
+		if (error instanceof PrismaClientKnownRequestError) {
+			setResponseStatus(event, 500);
+			return { message: error.message };
+		}
+	}
+
+	setResponseStatus(event, 500);
+	return { message: "A server error has occurred" };
+});

--- a/src/server/api/users/check-username.post.ts
+++ b/src/server/api/users/check-username.post.ts
@@ -1,4 +1,4 @@
-import prisma from "~/lib/prisma";
+import prisma from "~/server/lib/prisma";
 
 export default defineEventHandler(async (event) => {
 	const username = getQuery(event).username?.toString();

--- a/src/server/prisma/migrations/20250507143243_/migration.sql
+++ b/src/server/prisma/migrations/20250507143243_/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "conversations" ALTER COLUMN "updated_at" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "messages" ALTER COLUMN "updated_at" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "updated_at" DROP NOT NULL;

--- a/src/server/prisma/migrations/20250507152746_/migration.sql
+++ b/src/server/prisma/migrations/20250507152746_/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Type" AS ENUM ('direct', 'group');
+
+-- AlterTable
+ALTER TABLE "conversations" ADD COLUMN     "type" "Type" NOT NULL DEFAULT 'direct';

--- a/src/server/prisma/migrations/20250508092123_/migration.sql
+++ b/src/server/prisma/migrations/20250508092123_/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `create_at` on the `conversations` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "conversations" DROP COLUMN "create_at",
+ADD COLUMN     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/src/server/prisma/migrations/20250508142310_/migration.sql
+++ b/src/server/prisma/migrations/20250508142310_/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "conversation_members" DROP CONSTRAINT "conversation_members_conversation_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "conversation_members" DROP CONSTRAINT "conversation_members_user_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "messages" DROP CONSTRAINT "messages_conversation_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "conversation_members" ADD CONSTRAINT "conversation_members_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "conversation_members" ADD CONSTRAINT "conversation_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "messages" ADD CONSTRAINT "messages_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/server/prisma/models/Conversation.prisma
+++ b/src/server/prisma/models/Conversation.prisma
@@ -1,9 +1,15 @@
 model Conversation {
   id         String               @id @default(uuid())
-  create_at  DateTime             @default(now())
-  updated_at DateTime             @updatedAt
+  created_at DateTime             @default(now())
+  updated_at DateTime?            @updatedAt
+  type       Type                 @default(direct)
   members    ConversationMember[]
   messages   Message[]
 
   @@map("conversations")
+}
+
+enum Type {
+  direct
+  group
 }

--- a/src/server/prisma/models/ConversationMember.prisma
+++ b/src/server/prisma/models/ConversationMember.prisma
@@ -3,8 +3,8 @@ model ConversationMember {
   user_id         String       @db.Uuid
   conversation_id String
   joined_at       DateTime     @default(now())
-  conversation    Conversation @relation(fields: [conversation_id], references: [id])
-  user            User         @relation(fields: [user_id], references: [id])
+  conversation    Conversation @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
+  user            User         @relation(fields: [user_id], references: [id], onDelete: Cascade)
 
   @@unique([user_id, conversation_id])
   @@map("conversation_members")

--- a/src/server/prisma/models/Message.prisma
+++ b/src/server/prisma/models/Message.prisma
@@ -4,8 +4,8 @@ model Message {
   sender_id       String       @db.Uuid
   content         String
   created_at      DateTime     @default(now())
-  updated_at      DateTime     @updatedAt
-  conversation    Conversation @relation(fields: [conversation_id], references: [id])
+  updated_at      DateTime?     @updatedAt
+  conversation    Conversation @relation(fields: [conversation_id], references: [id], onDelete: Cascade)
   sender          User         @relation("Sender", fields: [sender_id], references: [id])
 
   @@map("messages")

--- a/src/server/prisma/models/User.prisma
+++ b/src/server/prisma/models/User.prisma
@@ -2,7 +2,7 @@ model User {
   id            String               @id @db.Uuid
   username      String               @unique
   created_at    DateTime             @default(now())
-  updated_at    DateTime             @updatedAt
+  updated_at    DateTime?             @updatedAt
   conversations ConversationMember[]
   sentMessages  Message[]            @relation("Sender")
 

--- a/src/server/validation/conversations.ts
+++ b/src/server/validation/conversations.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const findOrCreateDirectSchema = z.object({
+	otherMemberId: z
+		.string({ required_error: "Other Conversation Member ID required" })
+		.uuid({ message: "Not a valid UUID" })
+		.nonempty({ message: "Other Conversation Member ID required" })
+});

--- a/src/server/validation/messages.ts
+++ b/src/server/validation/messages.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const sendMessageSchema = z.object({
+	conversationId: z
+		.string({ required_error: "Conversation ID required" })
+		.uuid({ message: "Not a valid UUID" })
+		.nonempty({ message: "Conversation ID required" }),
+	content: z
+		.string({ required_error: "Please enter a message to send" })
+		.nonempty({ message: "Please enter a message to send" })
+		.max(2500, {
+			message: "Message content is too long. Maximum 2500 characters"
+		})
+});


### PR DESCRIPTION
- Add conversations/find-or-create-direct.post route to check if a conversation exist and creates one if it does not
- Add conversation zod object validation schema for find-or-create-direct route
- Update README
- Add resend block to LoginForm, so that if an unverified user tries to login, the verification email is sent again
- Update Prisma models:
 - Add cascade on delete for related records
 - Add enum Type field to Conversation model
- Add auto-login to confirm page (When a confirmation link is clicked and the user is redirected to the confirm page, they are now automatically logged in using a Supabase provided token hash)

Fixes #31